### PR TITLE
re Issue #12 removed GL_Version_Override to fix crasher

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,7 @@ extern crate stl_thumb;
 use std::process;
 use stl_thumb::config::Config;
 
-#[cfg(target_os = "linux")]
-use std::env;
-
-fn main() {
-    // Workaround for issues with OpenGL 3.1 on Mesa 18.3
-    #[cfg(target_os = "linux")]
-    env::set_var("MESA_GL_VERSION_OVERRIDE", "2.1");
-
+fn main() {    
     let config = Config::new();
 
     stderrlog::new()


### PR DESCRIPTION
This is pretty straightforward. I just removed the GL_Version_Override. I have confirmed that this works fine on Ubuntu 18.10. 

This is my OpenGL Version: OpenGL version string: 4.5 (Compatibility Profile) Mesa 18.3.3 - padoka PPA
Please let me know what you think. 

Thanks!