### PR TITLE
Macos support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_type"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "osmesa-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "stl-thumb"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -965,6 +973,7 @@ dependencies = [
  "image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mint 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stl_io 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1335,6 +1344,7 @@ dependencies = [
 "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
+"checksum os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69376b761943787ebd5cc85a5bc95958651a22609c5c1c2b65de21786baec72b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4.1"
 mint = "0.5.0"
 stderrlog = "0.4.0"
 stl_io = "0.3.7"
+os_type="2.2"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate image;
 #[macro_use]
 extern crate log;
 extern crate mint;
-
+extern crate os_type;
 pub mod config;
 mod mesh;
 
@@ -97,9 +97,13 @@ fn render_pipeline<F>(display: &F,
 
     // Load and compile shaders
     // ------------------------
-
-    let vertex_shader_src = include_str!("model.vert");
-    let pixel_shader_src = include_str!("model.frag");
+    let mut vertex_shader_src = include_str!("model.vert");
+    let mut pixel_shader_src = include_str!("model.frag");
+    let os = os_type::current_platform();
+    if os.os_type == os_type::OSType::OSX {
+        vertex_shader_src = include_str!("model_macos.vert");
+        pixel_shader_src = include_str!("model_macos.frag");
+    }
 
     // TODO: Cache program binary
     let program = glium::Program::from_source(display, &vertex_shader_src, &pixel_shader_src, None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate log;
 extern crate stderrlog;
-
 extern crate stl_thumb;
 
 use std::process;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,18 @@
 extern crate log;
 extern crate stderrlog;
 extern crate stl_thumb;
+extern crate os_type;
 
 use std::process;
 use stl_thumb::config::Config;
+use std::env;
 
-fn main() {    
+fn main() {
+    let os = os_type::current_platform();
+    if os.os_type == os_type::OSType::Arch {
+        env::set_var("MESA_GL_VERSION_OVERRIDE", "2.1");
+    }
     let config = Config::new();
-
     stderrlog::new()
         .module(module_path!())
         //.quiet(config.quiet)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,7 @@ extern crate stl_thumb;
 use std::process;
 use stl_thumb::config::Config;
 
-#[cfg(target_os = "linux")]
-use std::env;
-
-fn main() {
-    // Workaround for issues with OpenGL 3.1 on Mesa 18.3
-    #[cfg(target_os = "linux")]
-    env::set_var("MESA_GL_VERSION_OVERRIDE", "2.1");
-
+fn main() {    
     let config = Config::new();
 
     stderrlog::new()

--- a/src/model_macos.frag
+++ b/src/model_macos.frag
@@ -1,0 +1,8 @@
+#version 330
+
+out vec4 fragColor;
+
+void main()
+{
+    fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+}

--- a/src/model_macos.frag
+++ b/src/model_macos.frag
@@ -1,7 +1,7 @@
 #version 330
 
 out vec3 v_normal;
-out vec3 v_position;
+in vec3 v_position;
 
 uniform vec3 u_light;
 
@@ -22,7 +22,5 @@ void main() {
     // vec3 R = reflect( normalize(-u_light), normalize(v_normal) );
     // float cosAlpha = clamp( dot(camera_dir,R), 0, 1 );
     // float specular = pow( cosAlpha, 4.0 );
-
-    fragColor = vec4(ambient_color + diffuse * diffuse_color + specular * specular_color, 1.0);
+    fragColor = vec4(1.0, 0.0, 0.0, 1.0);
 }
-

--- a/src/model_macos.frag
+++ b/src/model_macos.frag
@@ -1,6 +1,6 @@
 #version 330
 
-out vec3 v_normal;
+in vec3 v_normal;
 in vec3 v_position;
 
 uniform vec3 u_light;

--- a/src/model_macos.frag
+++ b/src/model_macos.frag
@@ -1,8 +1,28 @@
 #version 330
 
+out vec3 v_normal;
+out vec3 v_position;
+
+uniform vec3 u_light;
+
+uniform vec3 ambient_color;
+uniform vec3 diffuse_color;
+uniform vec3 specular_color;
+
 out vec4 fragColor;
 
-void main()
-{
-    fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+void main() {
+    float diffuse = max(dot(normalize(v_normal), normalize(u_light)), 0.0);
+
+    vec3 camera_dir = normalize(-v_position);
+    vec3 half_direction = normalize(normalize(u_light) + camera_dir);
+    float specular = pow(max(dot(half_direction, normalize(v_normal)), 0.0), 16.0);
+
+    // Alternative specular method
+    // vec3 R = reflect( normalize(-u_light), normalize(v_normal) );
+    // float cosAlpha = clamp( dot(camera_dir,R), 0, 1 );
+    // float specular = pow( cosAlpha, 4.0 );
+
+    fragColor = vec4(ambient_color + diffuse * diffuse_color + specular * specular_color, 1.0);
 }
+

--- a/src/model_macos.frag
+++ b/src/model_macos.frag
@@ -22,5 +22,5 @@ void main() {
     // vec3 R = reflect( normalize(-u_light), normalize(v_normal) );
     // float cosAlpha = clamp( dot(camera_dir,R), 0, 1 );
     // float specular = pow( cosAlpha, 4.0 );
-    fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    fragColor = vec4(ambient_color + diffuse * diffuse_color + specular * specular_color, 1.0);
 }

--- a/src/model_macos.vert
+++ b/src/model_macos.vert
@@ -1,0 +1,12 @@
+#version 330
+
+layout(location = 0)in vec4 vert;
+
+uniform mat4 projection;
+uniform mat4 view;
+uniform mat4 model;
+
+void main()
+{
+    gl_Position = projection * view * model * vert;
+}

--- a/src/model_macos.vert
+++ b/src/model_macos.vert
@@ -1,12 +1,25 @@
 #version 330
 
-layout(location = 0)in vec4 vert;
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 normal;
 
-uniform mat4 projection;
-uniform mat4 view;
-uniform mat4 model;
+out vec3 v_normal;
+out vec3 v_position;
 
-void main()
-{
-    gl_Position = projection * view * model * vert;
+uniform mat4 perspective;
+//uniform mat4 view;
+//uniform mat4 model;
+uniform mat4 modelview;
+
+void main() {
+    // These never change, so they can be computed CPU side.
+    //mat4 modelview = view * model;
+
+    gl_Position = perspective * modelview * vec4(position, 1.0);
+    
+    vec4 p = modelview * vec4(position, 1.0);
+    v_position = p.xyz / p.w;
+
+    v_normal = mat3(modelview) * normal;
 }
+

--- a/src/model_macos.vert
+++ b/src/model_macos.vert
@@ -1,7 +1,7 @@
 #version 330
 
-layout(location = 0) in vec3 position;
-layout(location = 1) in vec3 normal;
+in vec3 position;
+in vec3 normal;
 
 out vec3 v_normal;
 out vec3 v_position;


### PR DESCRIPTION
For your consideration:  I have added macOS Mojave command line support

- Now checking for macOS special case
- In case of macOS, loading GLSL 330 vertex and shared files

I am happy to make any additions to the ReadMe re macOS configuration if you like. However, the only real dependency is Mojave and the standard Rust tool-chain. I would also be happy to create macOS binaries for the release page. 