### PR TITLE
Enhance RPM building and fix Nautilus thumbnails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,18 +75,13 @@ assets = [
     ["README.md",                       "usr/share/doc/stl-thumb/", "644"],
 ]
 
-[package.metadata.rpm]
-package = "stl-thumb"
-
-[package.metadata.rpm.cargo]
-buildflags = ["--release"]
-
-[package.metadata.rpm.targets]
-stl-thumb = { path = "/usr/bin/stl-thumb" }
-"libstl_thumb.so" = { path = "/usr/lib64/libstl_thumb.so" }
-"libstl_thumb.a" = { path = "/usr/lib64/libstl_thumb.a", mode = "644" }
-"../../libstl_thumb.h" = { path = "/usr/include/libstl_thumb.h", mode = "644"}
-"../../stl-thumb.thumbnailer" = { path = "/usr/share/thumbnailers/stl-thumb.thumbnailer", mode = "644"}
-"../../stl-thumb-mime.xml" = { path = "/usr/share/mime/packages/stl-thumb-mime.xml", mode = "644"}
-"../../README.md" = { path = "/usr/share/doc/stl-thumb/README.md", mode = "644"}
-
+[package.metadata.generate-rpm]
+assets = [
+    { source = "./target/release/stl-thumb",        dest = "/usr/bin/stl-thumb",                                mode = "755" },
+    { source = "./target/release/libstl_thumb.so",  dest = "/usr/lib64/libstl_thumb.so",                        mode = "755" },
+    { source = "./target/release/libstl_thumb.a",   dest = "/usr/lib64/libstl_thumb.a",                         mode = "644" },
+    { source = "libstl_thumb.h",                    dest = "/usr/include/libstl_thumb.h",                       mode = "644" },
+    { source = "stl-thumb.thumbnailer",             dest = "/usr/share/thumbnailers/stl-thumb.thumbnailer",     mode = "644" },
+    { source = "stl-thumb-mime.xml",                dest = "/usr/share/mime/packages/stl-thumb-mime.xml",       mode = "644" },
+    { source = "README.md",                         dest = "/usr/share/doc/stl-thumb/README.md",    doc = true, mode = "644" }
+]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ $ sudo zypper install stl-thumb
 ## Building
 
 ### Building the tool itself:
+If you get errors about fontconfig being missing, install the development package
+
 You can build the debug version with:
 ```
 $ cargo build
@@ -67,8 +69,8 @@ $ cargo deb
 ```
 ### Building the .rpm-package:
 ```
-$ cargo install cargo-rpm #this is an additional dependency
-$ cargo rpm build
+$ cargo install generate-rpm #this is an additional dependency
+$ cargo generate-rpm
 ```
 
 ## Command Line Usage

--- a/obj-thumb.thumbnailer
+++ b/obj-thumb.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=stl-thumb
-Exec=stl-thumb -f png -s %s %i %o
+Exec=xvfb-run --auto-servernum -w 0 stl-thumb -f png -s %s %i %o
 MimeType=model/obj;

--- a/stl-thumb.thumbnailer
+++ b/stl-thumb.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=stl-thumb
-Exec=stl-thumb -f png -s %s %i %o
+Exec=xvfb-run --auto-servernum -w 0 stl-thumb -f png -s %s %i %o
 MimeType=model/stl;model/x.stl-ascii;model/x.stl-binary;application/sla;


### PR DESCRIPTION
I have changed the RPM builder as the old one is unmaintained and I could not get it to work

I also added a workaround for bubblewrap breaking the functionality on Fedora 37.
The .thumbnailers files now use `xvfb-run` to run the program in an Xserver virtual environment. This feels a little slow to me but it does work. (thank you @sbrl for this)

I think that maybe there is a better way to implement my workaround, such as having seperate .thumbnailer files in the build that are put in the .rpm package. Let me know how/if you want me to implement this.