### PR TITLE
Update OS to 22.04, Added RPM compile

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,7 +13,7 @@ env:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/cache@v3
@@ -29,14 +30,16 @@ jobs:
         sudo apt-get update
         sudo apt-get install libosmesa6-dev
     - name: Build
-      run: cargo build --verbose
+      run: |
+        cargo build --release --verbose
+        strip -s target/release/stl-thumb
     - name: Run tests
       run: RUST_BACKTRACE=1 cargo test --verbose
 
   package:
     needs: [build]
     name: Package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [x86_64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, aarch64-unknown-linux-gnu]
@@ -70,9 +73,17 @@ jobs:
         fi
         rustup target add ${{ matrix.target }}
         cargo install cargo-deb --force
-    - name: Package
-      run: cargo deb --target ${{ matrix.target }}
+        cargo install cargo-generate-rpm --force
+    - name: Package DEB
+      run: |
+        cargo deb --target ${{ matrix.target }}
+    - name: Package RPM
+      run: |
+        cp -r ./target/${{ matrix.target }}/release ./target
+        cargo generate-rpm --target ${{ matrix.target }}
     - uses: actions/upload-artifact@v3
       with:
-        name: deb-${{ matrix.target }}
-        path: target/${{ matrix.target }}/debian/*.deb
+        name: deb-rpm-${{ matrix.target }}
+        path: |
+          target/${{ matrix.target }}/debian/*.deb
+          target/${{ matrix.target }}/generate-rpm/*.rpm

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -79,8 +79,7 @@ jobs:
         cargo deb --target ${{ matrix.target }}
     - name: Package RPM
       run: |
-        cp -r ./target/${{ matrix.target }}/release ./target
-        cargo generate-rpm --target ${{ matrix.target }}
+        cargo generate-rpm --target-dir ./target --target ${{ matrix.target }}
     - uses: actions/upload-artifact@v3
       with:
         name: deb-rpm-${{ matrix.target }}

--- a/.github/workflows/sources.list
+++ b/.github/workflows/sources.list
@@ -1,51 +1,51 @@
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
 # newer versions of the distribution.
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic main restricted
-deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted
-# deb-src http://us.archive.ubuntu.com/ubuntu/ bionic main restricted
+deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ jammy main restricted
+deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports jammy main restricted
+# deb-src http://us.archive.ubuntu.com/ubuntu/ jammy main restricted
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic-updates main restricted
-deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic-updates main restricted
-# deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates main restricted
+deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ jammy-updates main restricted
+deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted
+# deb-src http://us.archive.ubuntu.com/ubuntu/ jammy-updates main restricted
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team. Also, please note that software in universe WILL NOT receive any
 ## review or updates from the Ubuntu security team.
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic universe
-# deb-src http://us.archive.ubuntu.com/ubuntu/ bionic universe
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic-updates universe
-# deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates universe
+deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ jammy universe
+# deb-src http://us.archive.ubuntu.com/ubuntu/ jammy universe
+deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ jammy-updates universe
+# deb-src http://us.archive.ubuntu.com/ubuntu/ jammy-updates universe
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
 ## team, and may not be under a free licence. Please satisfy yourself as to 
 ## your rights to use the software. Also, please note that software in 
 ## multiverse WILL NOT receive any review or updates from the Ubuntu
 ## security team.
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic multiverse
-# deb-src http://us.archive.ubuntu.com/ubuntu/ bionic multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic-updates multiverse
-# deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates multiverse
+deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ jammy multiverse
+# deb-src http://us.archive.ubuntu.com/ubuntu/ jammy multiverse
+deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ jammy-updates multiverse
+# deb-src http://us.archive.ubuntu.com/ubuntu/ jammy-updates multiverse
 
 ## N.B. software from this repository may not have been tested as
 ## extensively as that contained in the main release, although it includes
 ## newer versions of some applications which may provide useful features.
 ## Also, please note that software in backports WILL NOT receive any review
 ## or updates from the Ubuntu security team.
-# deb http://us.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
-# deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
+# deb http://us.archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
+# deb-src http://us.archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
 
 ## Uncomment the following two lines to add software from Canonical's
 ## 'partner' repository.
 ## This software is not part of Ubuntu, but is offered by Canonical and the
 ## respective vendors as a service to Ubuntu users.
-# deb http://archive.canonical.com/ubuntu bionic partner
-# deb-src http://archive.canonical.com/ubuntu bionic partner
+# deb http://archive.canonical.com/ubuntu jammy partner
+# deb-src http://archive.canonical.com/ubuntu jammy partner
 
-deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu bionic-security main restricted
-# deb-src http://security.ubuntu.com/ubuntu bionic-security main restricted
-deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu bionic-security universe
-# deb-src http://security.ubuntu.com/ubuntu bionic-security universe
-deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu bionic-security multiverse
-# deb-src http://security.ubuntu.com/ubuntu bionic-security multiverse
+deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu jammy-security main restricted
+# deb-src http://security.ubuntu.com/ubuntu jammy-security main restricted
+deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu jammy-security universe
+# deb-src http://security.ubuntu.com/ubuntu jammy-security universe
+deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu jammy-security multiverse
+# deb-src http://security.ubuntu.com/ubuntu jammy-security multiverse


### PR DESCRIPTION
Updated base OS from 18.04 to 22.04 as the old version of Ubuntu wasn't able to be fetched.
Build set to Release, and strip out debugging flags.
Generation of RPM files for all 3 architectures setup inline with the DEB generation.
Added `workflow_dispatch:` to the workflow, allowing the the WebUI to trigger a workflow.

Artifacts for RPM and DEB are combined in one archive per architecture.