### PR TITLE
Revert "Update config.rs"

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -43,9 +43,9 @@ impl Default for Config {
             visible: false,
             verbosity: 0,
             material: Material {
-                ambient: [0.1552, 0.0086, 0.0266],
-                diffuse: [0.5432, 0.0301, 0.0931],
-                specular: [1.0, 1.0, 1.0],
+                ambient: [0.00, 0.13, 0.26],
+                diffuse: [0.38, 0.63, 1.00],
+                specular: [1.00, 1.00, 1.00],
             },
             background: (0.0, 0.0, 0.0, 0.0),
             aamethod: AAMethod::FXAA,


### PR DESCRIPTION
This reverts commit 93fd84e5c74be79ab8ef9e996f0e8c4d5c63ae36. This
commit changed the default color to red, but did not update the help
text that says the default is blue. This commit only says what it does
in Chinese and the PR only discusses the bug it fixed, so I think it was
an accidental inclusion.
