### PR TITLE
Lowercase extension when checking type

### DIFF
--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -126,6 +126,8 @@ impl Mesh {
                         .extension()
                         .and_then(std::ffi::OsStr::to_str)
                         .unwrap_or("")
+                        .to_lowercase()
+                        .as_str()
                     {
                         "obj" => Mesh::from_obj(stl_file, recalc_normals)?,
                         "stl" => Mesh::from_stl(stl_file, recalc_normals)?,


### PR DESCRIPTION
This checks for the lowercase extension when looking at the file type.

Otherwise, it fails on files with uppercase extension like `*.STL`.
