### PR TITLE
bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         cargo build --release
         cargo generate-rpm --target-dir ./target --target ${{ matrix.target }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: deb-rpm-${{ matrix.target }}
         path: |


### PR DESCRIPTION
upload-artifact v3 has been deprecated and blocks CI runs at this point. See:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/